### PR TITLE
Catch socket errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
-
+- Catch socket errors when requesting a remote search source. If we don't the
+  whole search results page fails with an error/traceback. [fredvd]
 
 1.2 (2016-12-23)
 ----------------

--- a/collective/multisearch/browser/portlet_remote_search.py
+++ b/collective/multisearch/browser/portlet_remote_search.py
@@ -205,6 +205,17 @@ class Renderer(portlet_local_search.Renderer):
                 return []
             logger.info('Unable to open RSS feed: %s' % search_url)
             return []
+        except socket.error as e:
+            if type(e) is tuple:
+                errmsg = e[1]
+            elif type(e) is str:
+                errmsg = e
+            else:
+                errmsg = "Uknonwn"
+                
+            logger.info('RSS feed socket error \'%s\' on url %s' % (errmsg, search_url))
+            return []
+
 
         data = feedparser.parse(rss)
         return [


### PR DESCRIPTION
when requesting remote searches